### PR TITLE
Feature/minimal timestep implementation

### DIFF
--- a/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
+++ b/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
@@ -46,7 +46,6 @@ ntheta_interp = resolution
 nzeta_interp = resolution
 
 # SAW parameters
-nParticles = 5000
 Phihat = -1.50119e3
 Phim = 1
 Phin = 1

--- a/src/simsopt/field/boozermagneticfield.py
+++ b/src/simsopt/field/boozermagneticfield.py
@@ -877,10 +877,10 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         ntor: (int) number of toroidal mode numbers for BOOZXFORM (defaults to
             32). Only used if a wout_*.nc file is passed.
         helicity_M : Poloidal helicity coefficient for enforcing field
-            quasi-symmetry If specified, then the non-symmetric Fourier harmonics of :math:`B` and :math:`K` are filtered out, so the field is a function of `chi = helicity_M*theta - helicity_N*zeta`. If helicity is unspecified, all harmonics are kept.
+            quasi-symmetry. If specified, then the non-symmetric Fourier harmonics of :math:`B` and :math:`K` are filtered out, so the field is a function of `chi = helicity_M*theta - helicity_N*zeta`. If helicity is unspecified, all harmonics are kept.
             (defaults to ``None``)
         helicity_N : Toroidal helicity coefficient for enforcing field
-            quasi-symmetry If specified, then the non-symmetric Fourier harmonics of :math:`B` and :math:`K` are filtered out, so the field is a function of `chi = helicity_M*theta - helicity_N*zeta`. If helicity is unspecified, all harmonics are kept.
+            quasi-symmetry. If specified, then the non-symmetric Fourier harmonics of :math:`B` and :math:`K` are filtered out, so the field is a function of `chi = helicity_M*theta - helicity_N*zeta`. If helicity is unspecified, all harmonics are kept.
         enforce_vacuum: If True, a vacuum field is assumed, :math:`G` is
             set to its mean value, :math:`I = 0`, and :math:`K = 0`.
         rescale: If True, use the interpolation method in the DELTA5D code.

--- a/src/simsopt/field/trajectory_helpers.py
+++ b/src/simsopt/field/trajectory_helpers.py
@@ -1038,6 +1038,8 @@ class PassingPerturbedPoincare:
         self.nprime = (self.Phim * self.helicity_N - self.Phin * self.helicity_M) / (
             self.helicity_Np * self.helicity_M - self.helicity_N * self.helicity_Mp
         )
+        if self.nprime == 0:
+            raise ValueError("nprime cannot be zero. Change the helicity coordinate eta and try again.")
 
         self.omegan = self.omega / self.nprime  # Frequency for Poincare slice
 

--- a/src/simsoptpp/python_tracing.cpp
+++ b/src/simsoptpp/python_tracing.cpp
@@ -22,6 +22,8 @@ void init_tracing(py::module_ &m){
         .def(py::init<int>());
     py::class_<StepSizeStoppingCriterion, shared_ptr<StepSizeStoppingCriterion>, StoppingCriterion>(m, "StepSizeStoppingCriterion")
         .def(py::init<double>());
+    py::class_<MinDtAccidents, shared_ptr<MinDtAccidents>, StoppingCriterion>(m, "MinDtAccidents")
+        .def(py::init<int>());
 
     m.def("particle_guiding_center_boozer_tracing", &particle_guiding_center_boozer_tracing,
         py::arg("field"),
@@ -77,6 +79,7 @@ void init_tracing(py::module_ &m){
         py::arg("vpars_stop")=false,
         py::arg("forget_exact_path")=false,
         py::arg("axis")=0,
-        py::arg("vpars")=vector<double>{}
+        py::arg("vpars")=vector<double>{},
+        py::arg("dt_min")=0.0
     );
 }

--- a/src/simsoptpp/tracing.h
+++ b/src/simsoptpp/tracing.h
@@ -36,7 +36,8 @@ particle_guiding_center_boozer_perturbed_tracing(
         bool vpars_stop=false,
         bool forget_exact_path=false,
         int axis=0,
-        vector<double> vpars={});
+        vector<double> vpars={},
+        double dt_min=0.0);
 
 
 tuple<vector<std::array<double, 5>>, vector<std::array<double, 6>>>

--- a/src/simsoptpp/tracing_helpers.h
+++ b/src/simsoptpp/tracing_helpers.h
@@ -105,6 +105,19 @@ class StepSizeStoppingCriterion : public StoppingCriterion {
         };
 };
 
+class MinDtAccidents : public StoppingCriterion {
+    private:
+        int max_accidents;
+        mutable int accident_count;
+    public:
+        MinDtAccidents(int max_accidents) : max_accidents(max_accidents), accident_count(0) {};
+        bool operator()(int iter, double dt, double t, double s, double theta, double zeta, double vpar=0) override {
+            return accident_count >= max_accidents;
+        };
+        void increment_accidents() const { accident_count++; };
+        int get_accident_count() const { return accident_count; };
+};
+
 template<std::size_t m, std::size_t n>
 array<double, m+n> join(const array<double, m>& a, const array<double, n>& b)
 {
@@ -339,7 +352,7 @@ bool check_stopping_criteria(RHS rhs, int iter, vector<array<double, RHS::Size+2
     for (int i = 0; i < stopping_criteria.size(); ++i) {
         if(stopping_criteria[i] && (*stopping_criteria[i])(iter, dt, t_current, s_current, theta_current, zeta_current, vpar_current)){
             stop = true;
-            res_hits.push_back(join<2, RHS::Size>({t_current, -1-double(i)}, stzvt_current));
+            res_hits.push_back(join<2, RHS::Size>({t_current, -2-double(i)}, stzvt_current));
             break;
         }
     }


### PR DESCRIPTION
Proposed implementation for dt_min in perturbed tracing. Records instances of dt_min as a res_hits with idx=-1. Therefore, any additional requested stopping criteria are now indexed as idx <= -2. 

Recording dt_min seems like a good idea, but may cause dense output if subsequent steps are again dt_min. In order to avoid MPI crash for this, the MinDtAccidents(number) stopping criterion can be called that will stop run if dt was < dt_min more than suggested number of times. 

Some other misc updates:
 - Asserting nprime is nonzero in Poincare cross section tool
 - Typo in examples and docs.
