### PR TITLE
Adding gpu tests to master.

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - gpu
+      - master
   pull_request:
     types:
       - labeled
@@ -10,7 +11,7 @@ on:
 
 jobs:
   tests:
-    if: contains(github.event.pull_request.labels.*.name, 'GPU CI')
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'GPU CI')
     runs-on: [GPU-runner]
     strategy:
       matrix:


### PR DESCRIPTION
## Summary by Sourcery

Enable CUDA CI tests to run on pushes to the master branch in addition to the GPU branch and labeled pull requests.

CI:
- Trigger the CUDA CI workflow on pushes to the master branch.
- Allow the CUDA CI tests job to run for all push events, not only labeled pull requests.