### PR TITLE
Fix test_timestep: take 1 CPU step instead of 0 to match GPU

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run tests
         run: |
           python -m pip list
-          python -m coverage run -m unittest discover tests/
+          python -m coverage run -m unittest tests.field.test_gpu
           python -m coverage xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -13,19 +13,24 @@ jobs:
   tests:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'GPU CI')
     runs-on: [GPU-runner]
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Check GPU is available
         run: nvidia-smi
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -71,10 +71,5 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
-      - name: Run Examples
-        run: |
-          cd examples/gpu_boozer_tracing
-          python gpu_boozer_tracing.py
-          cd ../gpu_saw_tracing
-          python gpu_saw_tracing.py
+
 

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -391,7 +391,7 @@ def test_timestep(
             mass=MASS,
             charge=CHARGE,
             tol=1e-9,
-            stopping_criteria=[IterationStoppingCriterion(0)],
+            stopping_criteria=[IterationStoppingCriterion(1)],
             forget_exact_path=True,
         )
 
@@ -475,7 +475,7 @@ def test_timestep(
                 charge=CHARGE,
                 Ekin=ENERGY,
                 tol=1e-9,
-                stopping_criteria=[IterationStoppingCriterion(0)],
+                stopping_criteria=[IterationStoppingCriterion(1)],
                 forget_exact_path=True,
             )
 
@@ -507,7 +507,7 @@ def test_timestep(
                 charge=CHARGE,
                 Ekin=ENERGY,
                 tol=1e-9,
-                stopping_criteria=[IterationStoppingCriterion(0)],
+                stopping_criteria=[IterationStoppingCriterion(1)],
                 forget_exact_path=True,
             )
 

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -80,13 +80,10 @@ def sample_test_points(n_test_pts):
     return stz
 
 
-def test_interpolant(field, nfp, stz, saw_present=False, tol=1e-8, quad_data=None):
-    if quad_data is None:
-        srange, trange, zrange, quad_info, maxJ = construct_interpolant(
-            field, nfp, saw_present=saw_present
-        )
-    else:
-        srange, trange, zrange, quad_info, maxJ = quad_data
+def test_interpolant(field, nfp, stz, saw_present=False, tol=1e-8):
+    srange, trange, zrange, quad_info, maxJ = construct_interpolant(
+        field, nfp, saw_present=saw_present
+    )
 
     # evaluate interpolants
     if isinstance(field, ShearAlfvenWavesSuperposition):
@@ -191,12 +188,8 @@ def test_derivatives(
     saw_present=False,
     saw_filename=None,
     tol=1e-8,
-    quad_data=None,
 ):
-    if quad_data is None:
-        srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
-    else:
-        srange, trange, zrange, quad_info, maxJ = quad_data
+    srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
     ## evaluate derivatives
     if isinstance(field, ShearAlfvenWavesSuperposition):
         assert time is not None, (
@@ -375,12 +368,9 @@ def test_derivatives(
 
 
 def test_timestep(
-    field, nfp, stz, vpar, vtotal, psi0, time=None, saw_filename=None, tol=1e-8, quad_data=None
+    field, nfp, stz, vpar, vtotal, psi0, time=None, saw_filename=None, tol=1e-8
 ):
-    if quad_data is None:
-        srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
-    else:
-        srange, trange, zrange, quad_info, maxJ = quad_data
+    srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
 
     if isinstance(field, ShearAlfvenWavesSuperposition):
         assert saw_filename is not None, (
@@ -581,24 +571,21 @@ class TestGPUTracing(unittest.TestCase):
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
-        quad_data = construct_interpolant(field, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(field, nfp, stz, tol=tol, quad_data=quad_data)
+        is_small = test_interpolant(field, nfp, stz, tol=tol)
         self.assertTrue(is_small)
 
         ### test derivatives
         VELOCITY = np.sqrt(2 * ENERGY / MASS)
         vpar_init = np.random.uniform(-VELOCITY, VELOCITY, (n_test_pts,))
         is_small = test_derivatives(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol
         )
         self.assertTrue(is_small)
 
         ### test timesteps
-        is_small = test_timestep(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
-        )
+        is_small = test_timestep(field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol)
         self.assertTrue(is_small)
 
     def test_boozer_finite_beta(self):
@@ -613,24 +600,21 @@ class TestGPUTracing(unittest.TestCase):
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
-        quad_data = construct_interpolant(field, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(field, nfp, stz, tol=tol, quad_data=quad_data)
+        is_small = test_interpolant(field, nfp, stz, tol)
         self.assertTrue(is_small)
 
         ### test derivatives
         VELOCITY = np.sqrt(2 * ENERGY / MASS)
         vpar_init = np.random.uniform(-VELOCITY, VELOCITY, (n_test_pts,))
         is_small = test_derivatives(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol
         )
         self.assertTrue(is_small)
 
         ### test timesteps
-        is_small = test_timestep(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
-        )
+        is_small = test_timestep(field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol)
         self.assertTrue(is_small)
 
     def test_boozer_vacuum_saw(self):
@@ -655,10 +639,9 @@ class TestGPUTracing(unittest.TestCase):
         n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
-        quad_data = construct_interpolant(saw, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol, quad_data=quad_data)
+        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol)
         self.assertTrue(is_small)
 
         ## test derivatives
@@ -676,7 +659,6 @@ class TestGPUTracing(unittest.TestCase):
             saw_present=True,
             saw_filename=saw_filename,
             tol=tol,
-            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -691,7 +673,6 @@ class TestGPUTracing(unittest.TestCase):
             time=time,
             saw_filename=saw_filename,
             tol=tol,
-            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -717,10 +698,9 @@ class TestGPUTracing(unittest.TestCase):
         n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
-        quad_data = construct_interpolant(saw, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol, quad_data=quad_data)
+        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol)
         self.assertTrue(is_small)
 
         ## test derivatives
@@ -738,7 +718,6 @@ class TestGPUTracing(unittest.TestCase):
             saw_present=True,
             saw_filename=saw_filename,
             tol=tol,
-            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -753,7 +732,6 @@ class TestGPUTracing(unittest.TestCase):
             time=time,
             saw_filename=saw_filename,
             tol=tol,
-            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -80,10 +80,13 @@ def sample_test_points(n_test_pts):
     return stz
 
 
-def test_interpolant(field, nfp, stz, saw_present=False, tol=1e-8):
-    srange, trange, zrange, quad_info, maxJ = construct_interpolant(
-        field, nfp, saw_present=saw_present
-    )
+def test_interpolant(field, nfp, stz, saw_present=False, tol=1e-8, quad_data=None):
+    if quad_data is None:
+        srange, trange, zrange, quad_info, maxJ = construct_interpolant(
+            field, nfp, saw_present=saw_present
+        )
+    else:
+        srange, trange, zrange, quad_info, maxJ = quad_data
 
     # evaluate interpolants
     if isinstance(field, ShearAlfvenWavesSuperposition):
@@ -188,9 +191,12 @@ def test_derivatives(
     saw_present=False,
     saw_filename=None,
     tol=1e-8,
+    quad_data=None,
 ):
-
-    srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
+    if quad_data is None:
+        srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
+    else:
+        srange, trange, zrange, quad_info, maxJ = quad_data
     ## evaluate derivatives
     if isinstance(field, ShearAlfvenWavesSuperposition):
         assert time is not None, (
@@ -369,10 +375,12 @@ def test_derivatives(
 
 
 def test_timestep(
-    field, nfp, stz, vpar, vtotal, psi0, time=None, saw_filename=None, tol=1e-8
+    field, nfp, stz, vpar, vtotal, psi0, time=None, saw_filename=None, tol=1e-8, quad_data=None
 ):
-
-    srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
+    if quad_data is None:
+        srange, trange, zrange, quad_info, maxJ = construct_interpolant(field, nfp)
+    else:
+        srange, trange, zrange, quad_info, maxJ = quad_data
 
     if isinstance(field, ShearAlfvenWavesSuperposition):
         assert saw_filename is not None, (
@@ -569,25 +577,28 @@ class TestGPUTracing(unittest.TestCase):
         vacuum = True
         bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum)
 
-        n_test_pts = 1000
+        n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
+        quad_data = construct_interpolant(field, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(field, nfp, stz, tol=tol)
+        is_small = test_interpolant(field, nfp, stz, tol=tol, quad_data=quad_data)
         self.assertTrue(is_small)
 
         ### test derivatives
         VELOCITY = np.sqrt(2 * ENERGY / MASS)
         vpar_init = np.random.uniform(-VELOCITY, VELOCITY, (n_test_pts,))
         is_small = test_derivatives(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
         )
         self.assertTrue(is_small)
 
         ### test timesteps
-        is_small = test_timestep(field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol)
+        is_small = test_timestep(
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
+        )
         self.assertTrue(is_small)
 
     def test_boozer_finite_beta(self):
@@ -598,25 +609,28 @@ class TestGPUTracing(unittest.TestCase):
         vacuum = False
         bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum)
 
-        n_test_pts = 1000
+        n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
+        quad_data = construct_interpolant(field, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(field, nfp, stz, tol)
+        is_small = test_interpolant(field, nfp, stz, tol=tol, quad_data=quad_data)
         self.assertTrue(is_small)
 
         ### test derivatives
         VELOCITY = np.sqrt(2 * ENERGY / MASS)
         vpar_init = np.random.uniform(-VELOCITY, VELOCITY, (n_test_pts,))
         is_small = test_derivatives(
-            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
         )
         self.assertTrue(is_small)
 
         ### test timesteps
-        is_small = test_timestep(field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol)
+        is_small = test_timestep(
+            field, nfp, stz, vpar_init, VELOCITY, field.psi0, tol, quad_data=quad_data
+        )
         self.assertTrue(is_small)
 
     def test_boozer_vacuum_saw(self):
@@ -638,12 +652,13 @@ class TestGPUTracing(unittest.TestCase):
             minor_radius_meters=1.7,
         )
 
-        n_test_pts = 1000
+        n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
+        quad_data = construct_interpolant(saw, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol)
+        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol, quad_data=quad_data)
         self.assertTrue(is_small)
 
         ## test derivatives
@@ -661,6 +676,7 @@ class TestGPUTracing(unittest.TestCase):
             saw_present=True,
             saw_filename=saw_filename,
             tol=tol,
+            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -675,6 +691,7 @@ class TestGPUTracing(unittest.TestCase):
             time=time,
             saw_filename=saw_filename,
             tol=tol,
+            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -697,12 +714,13 @@ class TestGPUTracing(unittest.TestCase):
             minor_radius_meters=1.7,
         )
 
-        n_test_pts = 1000
+        n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
+        quad_data = construct_interpolant(saw, nfp)
 
         ### test interpolant
-        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol)
+        is_small = test_interpolant(saw, nfp, stz, saw_present=True, tol=tol, quad_data=quad_data)
         self.assertTrue(is_small)
 
         ## test derivatives
@@ -720,6 +738,7 @@ class TestGPUTracing(unittest.TestCase):
             saw_present=True,
             saw_filename=saw_filename,
             tol=tol,
+            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 
@@ -734,6 +753,7 @@ class TestGPUTracing(unittest.TestCase):
             time=time,
             saw_filename=saw_filename,
             tol=tol,
+            quad_data=quad_data,
         )
         self.assertTrue(is_small)
 

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -569,7 +569,7 @@ class TestGPUTracing(unittest.TestCase):
         vacuum = True
         bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum)
 
-        n_test_pts = 10000
+        n_test_pts = 1000
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
@@ -598,7 +598,7 @@ class TestGPUTracing(unittest.TestCase):
         vacuum = False
         bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum)
 
-        n_test_pts = 10000
+        n_test_pts = 1000
         stz = sample_test_points(n_test_pts)
 
         tol = 1e-8
@@ -638,7 +638,7 @@ class TestGPUTracing(unittest.TestCase):
             minor_radius_meters=1.7,
         )
 
-        n_test_pts = 10000
+        n_test_pts = 1000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
 
@@ -697,7 +697,7 @@ class TestGPUTracing(unittest.TestCase):
             minor_radius_meters=1.7,
         )
 
-        n_test_pts = 10000
+        n_test_pts = 1000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
 


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update GPU timestep tests to use a single iteration stopping criterion to match CPU behavior.