### PR TITLE
Add CI example testing and fix passing map WBA bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,51 @@ jobs:
         flags: unittests
         name: codecov-umbrella
 
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install netCDF4
+        pip install -e ".[dev]"
+      env:
+        NETCDF_DIR: /usr
+        HDF5_DIR: /usr
+        GSL_DIR: /usr
+
+    - name: Run examples
+      run: |
+        python examples/fusion_distribution/fusion_distribution.py
+        python examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
+        python examples/uniform_surf_distribution/uniform_surf_distribution.py
+        python examples/uniform_vol_distribution/uniform_vol_distribution.py
+        python examples/plot_trajectory/plot_trajectory.py
+        python examples/orbit_classification/fusion_distribution_classification.py
+        python examples/passing_map_unperturbed/passing_map.py
+        python examples/passing_map_perturbed_QA/passing_map_perturbed.py
+        python examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
+        python examples/passing_map_perturbed_QH/passing_map_perturbed.py
+        python examples/trapped_map/trapped_map.py
+        python examples/trapped_map_QI/trapped_map_QI.py
+        python examples/passing_frequencies/passing_frequencies.py
+        python examples/trapped_frequencies/trapped_frequencies.py
+        python examples/tracing_with_AE/tracing_with_AE.py
+        python examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
+
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,9 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config
+        sudo apt-get install -y --no-install-recommends \
+          cmake ninja-build libboost-all-dev libopenmpi-dev \
+          libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,22 +108,22 @@ jobs:
 
     - name: Run examples
       run: |
-        python examples/fusion_distribution/fusion_distribution.py
-        python examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
-        python examples/uniform_surf_distribution/uniform_surf_distribution.py
-        python examples/uniform_vol_distribution/uniform_vol_distribution.py
-        python examples/plot_trajectory/plot_trajectory.py
-        python examples/orbit_classification/fusion_distribution_classification.py
-        python examples/passing_map_unperturbed/passing_map.py
-        python examples/passing_map_perturbed_QA/passing_map_perturbed.py
-        python examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
-        python examples/passing_map_perturbed_QH/passing_map_perturbed.py
-        python examples/trapped_map/trapped_map.py
-        python examples/trapped_map_QI/trapped_map_QI.py
-        python examples/passing_frequencies/passing_frequencies.py
-        python examples/trapped_frequencies/trapped_frequencies.py
-        python examples/tracing_with_AE/tracing_with_AE.py
-        python examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
+        (cd examples/fusion_distribution && python fusion_distribution.py)
+        (cd examples/fusion_distribution_perturbed && python fusion_distribution_perturbed.py)
+        (cd examples/uniform_surf_distribution && python uniform_surf_distribution.py)
+        (cd examples/uniform_vol_distribution && python uniform_vol_distribution.py)
+        (cd examples/plot_trajectory && python plot_trajectory.py)
+        (cd examples/orbit_classification && python fusion_distribution_classification.py)
+        (cd examples/passing_map_unperturbed && python passing_map.py)
+        (cd examples/passing_map_perturbed_QA && python passing_map_perturbed.py)
+        (cd examples/passing_map_perturbed_QA_WBA && python passing_map_perturbed.py)
+        (cd examples/passing_map_perturbed_QH && python passing_map_perturbed.py)
+        (cd examples/trapped_map && python trapped_map.py)
+        (cd examples/trapped_map_QI && python trapped_map_QI.py)
+        (cd examples/passing_frequencies && python passing_frequencies.py)
+        (cd examples/trapped_frequencies && python trapped_frequencies.py)
+        (cd examples/tracing_with_AE && python tracing_with_AE.py)
+        (cd examples/tracing_with_FAR3D_IVP && python tracing_with_FAR3D_AE.py)
 
   docs:
     name: Build Documentation

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config nvidia-cuda-toolkit
+          sudo apt-get install -y --no-install-recommends cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -40,7 +40,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install netCDF4 cmake ninja "pybind11<=2.13.6" setuptools wheel pandas
-          NVCC_PATH=$(which nvcc)          
+          export PATH=/usr/local/cuda/bin:$PATH
+          NVCC_PATH=$(which nvcc)
           echo "Using NVCC at: $NVCC_PATH"
 
           export CUDACXX=$NVCC_PATH

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -71,5 +71,10 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
+      - name: Run GPU examples
+        run: |
+          (cd examples/gpu_boozer_tracing && python gpu_boozer_tracing.py)
+          (cd examples/gpu_saw_tracing && python gpu_saw_tracing.py)
+
 
 

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -35,14 +35,14 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config
+          sudo apt-get install -y --no-install-recommends cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config cuda-nvcc-12-8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install netCDF4 cmake ninja "pybind11<=2.13.6" setuptools wheel pandas
           NVCC_PATH=$(command -v nvcc 2>/dev/null \
-            || find /usr/local/cuda* /usr/cuda* -maxdepth 3 -name nvcc -type f 2>/dev/null \
-            | head -1 || true)
+            || find /usr/local/cuda* -maxdepth 3 -name nvcc -type f 2>/dev/null | head -1 \
+            || true)
           echo "Using NVCC at: ${NVCC_PATH:-not found}"
           export CUDACXX=${NVCC_PATH}
           pip install -v --no-build-isolation -e ".[dev]" 2>&1 | tee install.log

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config cuda-nvcc-12-8
+          sudo apt-get install -y --no-install-recommends cmake ninja-build libboost-all-dev libopenmpi-dev libnetcdf-dev libhdf5-dev libnetcdf-c++4-dev libgsl-dev pkg-config nvidia-cuda-toolkit
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -40,11 +40,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install netCDF4 cmake ninja "pybind11<=2.13.6" setuptools wheel pandas
-          export PATH=/usr/local/cuda/bin:$PATH
-          NVCC_PATH=$(which nvcc)
-          echo "Using NVCC at: $NVCC_PATH"
-
-          export CUDACXX=$NVCC_PATH
+          NVCC_PATH=$(command -v nvcc 2>/dev/null \
+            || find /usr/local/cuda* /usr/cuda* -maxdepth 3 -name nvcc -type f 2>/dev/null \
+            | head -1 || true)
+          echo "Using NVCC at: ${NVCC_PATH:-not found}"
+          export CUDACXX=${NVCC_PATH}
           pip install -v --no-build-isolation -e ".[dev]" 2>&1 | tee install.log
           pip install coverage
         env:

--- a/examples/fusion_distribution/fusion_distribution.py
+++ b/examples/fusion_distribution/fusion_distribution.py
@@ -99,7 +99,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from firm3d.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=1e-2)

--- a/examples/fusion_distribution/fusion_distribution.py
+++ b/examples/fusion_distribution/fusion_distribution.py
@@ -19,19 +19,19 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 time1 = time.time()
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
+++ b/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
@@ -115,7 +115,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from firm3d.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=1e-2)

--- a/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
+++ b/examples/fusion_distribution_perturbed/fusion_distribution_perturbed.py
@@ -20,17 +20,17 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/gpu_boozer_tracing/gpu_boozer_tracing.py
+++ b/examples/gpu_boozer_tracing/gpu_boozer_tracing.py
@@ -18,7 +18,12 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
+from firm3d.util.functions import in_github_actions
 from firm3d.util.mpi import comm_world
+
+resolution = 5 if in_github_actions else 15  # Resolution for field interpolation
+nparticles = 100 if in_github_actions else 1000  # Number of particles to trace
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 
 ### CREATE A FIELD FOR TRACING
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
@@ -27,15 +32,12 @@ bri = BoozerRadialInterpolant(boozmn_filename, 3, comm=comm_world, enforce_vacuu
 field = InterpolatedBoozerField(
     bri,
     3,
-    ns_interp=15,
-    ntheta_interp=15,
-    nzeta_interp=15,
+    ns_interp=resolution,
+    ntheta_interp=resolution,
+    nzeta_interp=resolution,
 )
 # set seed for consistency
 np.random.seed(8)
-
-# trace particles
-nparticles = 1000
 
 # Define fusion birth distribution
 # Bader, A., et al. "Modeling of energetic particle transport in optimized
@@ -74,10 +76,10 @@ last_time = trace_particles_boozer_gpu(
     mass=mass,
     charge=charge,
     vtotal=vpar0,
-    tol=1e-8,
-    ns=15,
-    ntheta=15,
-    nzeta=15,
+    tol=tol,
+    ns=resolution,
+    ntheta=resolution,
+    nzeta=resolution,
 )
 particle_data = pd.DataFrame(
     {

--- a/examples/gpu_saw_tracing/gpu_saw_tracing.py
+++ b/examples/gpu_saw_tracing/gpu_saw_tracing.py
@@ -12,14 +12,15 @@ from firm3d.saw.ae3d import AE3DEigenvector
 from firm3d.util.constants import ALPHA_PARTICLE_CHARGE as CHARGE
 from firm3d.util.constants import ALPHA_PARTICLE_MASS as MASS
 from firm3d.util.constants import FUSION_ALPHA_PARTICLE_ENERGY as ENERGY
+from firm3d.util.functions import in_github_actions
 from firm3d.util.gpu_utils import boozer_saw_interpolant
 from firm3d.util.sampling import sample_stz
 
 np.random.seed(1800)
 
 ### tracing parameters
-nparticles = 25000
-tmax = 1e-3
+nparticles = 100 if in_github_actions else 25000  # Number of particles to trace
+tmax = 1e-4 if in_github_actions else 1e-3  # Time for integration
 
 
 ### CREATE A FIELD FOR TRACING
@@ -28,7 +29,7 @@ bri = BoozerRadialInterpolant(boozmn_filename, 3, enforce_vacuum=True)
 
 nfp = bri.nfp
 degree = 3
-n_metagrid_pts = 15
+n_metagrid_pts = 5 if in_github_actions else 15  # Resolution for field interpolation
 srange = (0, 1, n_metagrid_pts)
 thetarange = (0, np.pi, n_metagrid_pts)
 zetarange = (0, 2 * np.pi / nfp, n_metagrid_pts)
@@ -64,6 +65,7 @@ VELOCITY = np.sqrt(2 * ENERGY / MASS)
 vpar_init = np.random.uniform(-VELOCITY, VELOCITY, (nparticles,))
 stz = np.ascontiguousarray(stz_inits)
 
+tol = 1e-4 if in_github_actions else 1e-9  # Tolerance for ODE solver
 last_time = trace_particles_boozer_gpu(
     saw,
     stz,
@@ -72,7 +74,7 @@ last_time = trace_particles_boozer_gpu(
     MASS,
     CHARGE,
     np.sqrt(2 * ENERGY / MASS),
-    1e-9,
+    tol,
     n_metagrid_pts,
     n_metagrid_pts,
     n_metagrid_pts,

--- a/examples/orbit_classification/fusion_distribution_classification.py
+++ b/examples/orbit_classification/fusion_distribution_classification.py
@@ -22,7 +22,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print
+from firm3d.util.functions import in_github_actions, proc0_print
 
 try:
     from mpi4py import MPI
@@ -37,14 +37,14 @@ except ImportError:
 
 time1 = time.time()
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_ariescs.nc"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/passing_frequencies/passing_frequencies.py
+++ b/examples/passing_frequencies/passing_frequencies.py
@@ -12,7 +12,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
@@ -21,17 +21,17 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 ntheta_poinc = 1  # Number of zeta initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 100  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 100  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 degree = 3  # Degree for Lagrange interpolation
 
 # Setup logging to redirect output to file

--- a/examples/passing_frequencies/passing_frequencies.py
+++ b/examples/passing_frequencies/passing_frequencies.py
@@ -72,7 +72,7 @@ points[:, 0] = s_prof
 field.set_points(points)
 iota = field.iota()[:, 0]
 
-if verbose:
+if verbose and not in_github_actions:
     import matplotlib
 
     matplotlib.use("Agg")  # Don't use interactive backend

--- a/examples/passing_frequencies/passing_frequencies.py
+++ b/examples/passing_frequencies/passing_frequencies.py
@@ -25,7 +25,7 @@ resolution = 10 if in_github_actions else 48  # Resolution for field interpolati
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 ntheta_poinc = 1  # Number of zeta initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 100  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/passing_map_perturbed_QA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA/passing_map_perturbed.py
@@ -26,7 +26,7 @@ resolution = 10 if in_github_actions else 48  # Resolution for field interpolati
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/passing_map_perturbed_QA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA/passing_map_perturbed.py
@@ -89,7 +89,7 @@ poinc = PassingPerturbedPoincare(
     solver_options={"reltol": tol, "abstol": tol},
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare()
 
 time2 = time.time()

--- a/examples/passing_map_perturbed_QA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA/passing_map_perturbed.py
@@ -13,7 +13,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
@@ -22,17 +22,17 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 degree = 3  # Degree for Lagrange interpolation
 helicity_M = 1  # field strength helicity (QA)
 helicity_N = 0  # field strength helicity (QA)

--- a/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
@@ -26,7 +26,7 @@ resolution = 10 if in_github_actions else 50  # Resolution for field interpolati
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 100  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 100  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
@@ -13,7 +13,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
@@ -22,17 +22,17 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 50  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 50  # Resolution for field interpolation
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 100  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 100  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 degree = 3  # Degree for Lagrange interpolation
 helicity_M = 1  # field strength helicity (QA)
 helicity_N = 0  # field strength helicity (QA)

--- a/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QA_WBA/passing_map_perturbed.py
@@ -90,7 +90,7 @@ poinc = PassingPerturbedPoincare(
     comm=comm_world,
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare()
 
 time2 = time.time()

--- a/examples/passing_map_perturbed_QH/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QH/passing_map_perturbed.py
@@ -26,7 +26,7 @@ resolution = 10 if in_github_actions else 48  # Resolution for field interpolati
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/passing_map_perturbed_QH/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QH/passing_map_perturbed.py
@@ -13,7 +13,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_beta2.5_QH.nc"
@@ -22,17 +22,17 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.1  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 nchi_poinc = 1  # Number of chi initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 degree = 3  # Degree for Lagrange interpolation
 helicity_M = 1  # field strength helicity (QH)
 helicity_N = -4  # field strength helicity (QH)

--- a/examples/passing_map_perturbed_QH/passing_map_perturbed.py
+++ b/examples/passing_map_perturbed_QH/passing_map_perturbed.py
@@ -89,7 +89,7 @@ poinc = PassingPerturbedPoincare(
     solver_options={"reltol": tol, "abstol": tol},
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare()
 
 time2 = time.time()

--- a/examples/passing_map_unperturbed/passing_map.py
+++ b/examples/passing_map_unperturbed/passing_map.py
@@ -61,7 +61,7 @@ poinc = PassingPoincare(
     solver_options={"reltol": tol, "abstol": tol},
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare()
 
 time2 = time.time()

--- a/examples/passing_map_unperturbed/passing_map.py
+++ b/examples/passing_map_unperturbed/passing_map.py
@@ -23,7 +23,7 @@ resolution = 10 if in_github_actions else 48  # Resolution for field interpolati
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.0  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 ntheta_poinc = 1  # Number of zeta initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/passing_map_unperturbed/passing_map.py
+++ b/examples/passing_map_unperturbed/passing_map.py
@@ -10,7 +10,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
@@ -19,17 +19,17 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 sign_vpar = 1.0  # sign(vpar). should be +/- 1.
 lam = 0.0  # lambda = v_perp^2/(v^2 B) = const. along trajectory
 ntheta_poinc = 1  # Number of zeta initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 degree = 3  # Degree for Lagrange interpolation
 
 # Setup logging to redirect output to file

--- a/examples/plot_trajectory/plot_trajectory.py
+++ b/examples/plot_trajectory/plot_trajectory.py
@@ -19,17 +19,17 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 time1 = time.time()
 
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
 order = 3  # Order for radial interpolation
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 tmax = 1e-4  # Time for integration
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 degree = 3  # Degree for 3d interpolation
 ns_interp = resolution
 ntheta_interp = resolution

--- a/examples/plot_trajectory/plot_trajectory.py
+++ b/examples/plot_trajectory/plot_trajectory.py
@@ -88,13 +88,13 @@ proc0_print("Elapsed time for tracing: ", time2 - time1)
 
 ax = plot_trajectory_overhead_cyl(traj_booz[0], field)
 
-if verbose:
+if verbose and not in_github_actions:
     fig = ax.figure
     fig.savefig("trajectory_overhead_cyl.png", dpi=300, bbox_inches="tight")
 
 ax = plot_trajectory_poloidal(traj_booz[0], helicity_N=nfp)
 
-if verbose:
+if verbose and not in_github_actions:
     fig = ax.figure
     fig.savefig("trajectory_poloidal.png", dpi=300, bbox_inches="tight")
 

--- a/examples/tracing_with_AE/tracing_with_AE.py
+++ b/examples/tracing_with_AE/tracing_with_AE.py
@@ -21,18 +21,18 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
 saw_filename = "ae.npy"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/tracing_with_AE/tracing_with_AE.py
+++ b/examples/tracing_with_AE/tracing_with_AE.py
@@ -114,7 +114,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from firm3d.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=tmax)

--- a/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
+++ b/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
@@ -114,7 +114,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from simsopt.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=1e-2)

--- a/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
+++ b/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
@@ -21,18 +21,18 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 resolution = 5  # Resolution for field interpolation
 nParticles = 5  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_beta2.5_QH.nc"
 saw_filename = "./far3d_firm3d_out.npy"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/trapped_frequencies/trapped_frequencies.py
+++ b/examples/trapped_frequencies/trapped_frequencies.py
@@ -12,7 +12,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
@@ -21,15 +21,15 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 1  # Number of eta initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 s_mirror = 0.5  # flux surface for mirroring
 theta_mirror = np.pi / 2  # poloidal angle for mirroring
 zeta_mirror = 0

--- a/examples/trapped_frequencies/trapped_frequencies.py
+++ b/examples/trapped_frequencies/trapped_frequencies.py
@@ -23,7 +23,7 @@ Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
 resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 1  # Number of eta initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/trapped_frequencies/trapped_frequencies.py
+++ b/examples/trapped_frequencies/trapped_frequencies.py
@@ -75,7 +75,7 @@ poinc = TrappedPoincare(
 
 omega_eta_prof, omega_b_prof, s_prof = poinc.compute_frequencies()
 
-if verbose:
+if verbose and not in_github_actions:
     import matplotlib
 
     matplotlib.use("Agg")  # Don't use interactive backend

--- a/examples/trapped_map/trapped_map.py
+++ b/examples/trapped_map/trapped_map.py
@@ -12,7 +12,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_beta2.5_QA.nc"
@@ -21,15 +21,15 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 5  # Number of eta initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 s_mirror = 0.5  # flux surface for mirroring
 theta_mirror = np.pi / 2  # poloidal angle for mirroring
 zeta_mirror = 0

--- a/examples/trapped_map/trapped_map.py
+++ b/examples/trapped_map/trapped_map.py
@@ -70,7 +70,7 @@ poinc = TrappedPoincare(
     tmax=1e-4,
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare()
 
 time2 = time.time()

--- a/examples/trapped_map/trapped_map.py
+++ b/examples/trapped_map/trapped_map.py
@@ -23,7 +23,7 @@ Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
 resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 5  # Number of eta initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/trapped_map_QI/trapped_map_QI.py
+++ b/examples/trapped_map_QI/trapped_map_QI.py
@@ -71,7 +71,7 @@ poinc = TrappedPoincare(
     tmax=1e-4,
 )
 
-if verbose:
+if verbose and not in_github_actions:
     poinc.plot_poincare(filename="trapped_map_QI.pdf")
 
 time2 = time.time()

--- a/examples/trapped_map_QI/trapped_map_QI.py
+++ b/examples/trapped_map_QI/trapped_map_QI.py
@@ -12,7 +12,7 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 boozmn_filename = "../inputs/boozmn_nfp3_rescaled.nc"
@@ -21,15 +21,15 @@ charge = ALPHA_PARTICLE_CHARGE
 mass = ALPHA_PARTICLE_MASS
 Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
-resolution = 48  # Resolution for field interpolation
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 5  # Number of eta initial conditions for poincare
-ns_poinc = 120  # Number of s initial conditions for poincare
-Nmaps = 1000  # Number of Poincare return maps to compute
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation
 nzeta_interp = resolution  # number of toroidal grid points for interpolation
 order = 3  # order for interpolation
-tol = 1e-8  # Tolerance for ODE solver
+tol = 1e-4 if in_github_actions else 1e-8  # Tolerance for ODE solver
 s_mirror = 0.5  # flux surface for mirroring
 theta_mirror = 0  # poloidal angle for mirroring
 helicity_M = 0  # helicity of field strength contours

--- a/examples/trapped_map_QI/trapped_map_QI.py
+++ b/examples/trapped_map_QI/trapped_map_QI.py
@@ -23,7 +23,7 @@ Ekin = FUSION_ALPHA_PARTICLE_ENERGY
 
 resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
 neta_poinc = 5  # Number of eta initial conditions for poincare
-ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions for poincare
+ns_poinc = 5 if in_github_actions else 120  # Number of s initial conditions
 Nmaps = 5 if in_github_actions else 1000  # Number of Poincare return maps to compute
 ns_interp = resolution  # number of radial grid points for interpolation
 ntheta_interp = resolution  # number of poloidal grid points for interpolation

--- a/examples/uniform_surf_distribution/uniform_surf_distribution.py
+++ b/examples/uniform_surf_distribution/uniform_surf_distribution.py
@@ -19,19 +19,19 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 time1 = time.time()
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/uniform_surf_distribution/uniform_surf_distribution.py
+++ b/examples/uniform_surf_distribution/uniform_surf_distribution.py
@@ -80,7 +80,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from firm3d.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=1e-2)

--- a/examples/uniform_vol_distribution/uniform_vol_distribution.py
+++ b/examples/uniform_vol_distribution/uniform_vol_distribution.py
@@ -19,19 +19,19 @@ from firm3d.util.constants import (
     ALPHA_PARTICLE_MASS,
     FUSION_ALPHA_PARTICLE_ENERGY,
 )
-from firm3d.util.functions import proc0_print, setup_logging
+from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
 time1 = time.time()
 
-resolution = 48  # Resolution for field interpolation
-nParticles = 5000  # Number of particles to trace
-reltol = 1e-8  # Relative tolerance for the ODE solver
-abstol = 1e-8  # Absolute tolerance for the ODE solver
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
+reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
+abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation
 degree = 3  # Degree for 3d interpolation
 boozmn_filename = "../inputs/boozmn_aten_rescaled.nc"
-tmax = 1e-2  # Time for integration
+tmax = 1e-4 if in_github_actions else 1e-2  # Time for integration
 ns_interp = resolution
 ntheta_interp = resolution
 nzeta_interp = resolution

--- a/examples/uniform_vol_distribution/uniform_vol_distribution.py
+++ b/examples/uniform_vol_distribution/uniform_vol_distribution.py
@@ -80,7 +80,7 @@ time2 = time.time()
 proc0_print("Elapsed time for tracing = ", time2 - time1)
 
 ## Post-process results to obtain lost particles
-if verbose:
+if verbose and not in_github_actions:
     from firm3d.field.trajectory_helpers import compute_loss_fraction
 
     times, loss_frac = compute_loss_fraction(res_tys, tmin=1e-5, tmax=1e-2)

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -1,4 +1,3 @@
-from math import sqrt
 from warnings import warn
 
 import numpy as np

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -216,9 +216,9 @@ def trace_particles_boozer_perturbed(
             np.asarray([[stz_inits[0, 0]], [stz_inits[0, 1]], [stz_inits[0, 2]], [0]]).T
         )
         B0 = perturbed_field.B0.modB()[0, 0]
-        speed_total = sqrt(speed_par[0] ** 2 + 2 * mus[0] * B0)
+        speed_total = float(np.sqrt(speed_par[0] ** 2 + 2 * mus[0] * B0))
     else:
-        speed_total = sqrt(2 * Ekin / m)
+        speed_total = float(np.sqrt(2 * Ekin / m))
 
     if mode is not None:
         mode = mode.lower()
@@ -239,22 +239,22 @@ def trace_particles_boozer_perturbed(
     for i in range(first, last):
         res_ty, res_hit = sopp.particle_guiding_center_boozer_perturbed_tracing(
             perturbed_field,
-            stz_inits[i, :],
-            m,
-            charge,
-            speed_total,
-            speed_par[i],
-            mus[i],
-            tmax,
-            abstol,
-            reltol,
+            stz_inits[i, :].tolist(),
+            float(m),
+            float(charge),
+            float(speed_total),
+            float(speed_par[i]),
+            float(mus[i]),
+            float(tmax),
+            float(abstol),
+            float(reltol),
             vacuum=(mode == "gc_vac"),
             noK=(mode == "gc_nok"),
-            phases=phases,
-            n_zetas=n_zetas,
-            m_thetas=m_thetas,
-            omegas=omegas,
-            vpars=vpars,
+            phases=[float(p) for p in phases],
+            n_zetas=[float(x) for x in n_zetas],
+            m_thetas=[float(x) for x in m_thetas],
+            omegas=[float(x) for x in omegas],
+            vpars=[float(x) for x in vpars],
             stopping_criteria=stopping_criteria,
             dt_save=dt_save,
             phases_stop=phases_stop,

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -188,16 +188,11 @@ def trace_particles_boozer_perturbed(
     """
     if stopping_criteria is None:
         stopping_criteria = []
-    if vpars is None:
-        vpars = []
-    if phases is None:
-        phases = []
-    if n_zetas is None:
-        n_zetas = []
-    if m_thetas is None:
-        m_thetas = []
-    if omegas is None:
-        omegas = []
+    phases = [float(p) for p in (phases or [])]
+    vpars = [float(x) for x in (vpars or [])]
+    n_zetas = [float(x) for x in (n_zetas or [])]
+    m_thetas = [float(x) for x in (m_thetas or [])]
+    omegas = [float(x) for x in (omegas or [])]
     if reltol is None:
         reltol = tol
     if abstol is None:
@@ -249,11 +244,11 @@ def trace_particles_boozer_perturbed(
             float(reltol),
             vacuum=(mode == "gc_vac"),
             noK=(mode == "gc_nok"),
-            phases=[float(p) for p in phases],
-            n_zetas=[float(x) for x in n_zetas],
-            m_thetas=[float(x) for x in m_thetas],
-            omegas=[float(x) for x in omegas],
-            vpars=[float(x) for x in vpars],
+            phases=phases,
+            n_zetas=n_zetas,
+            m_thetas=m_thetas,
+            omegas=omegas,
+            vpars=vpars,
             stopping_criteria=stopping_criteria,
             dt_save=dt_save,
             phases_stop=phases_stop,

--- a/src/firm3d/field/trajectory_helpers.py
+++ b/src/firm3d/field/trajectory_helpers.py
@@ -1379,7 +1379,9 @@ class PassingPerturbedPoincare:
                 helicity_M,
                 helicity_N,
             )
-            self.Eprime = float(self.nprime * Ekin - self.omega * float(Peta0.squeeze()))
+            self.Eprime = float(
+                self.nprime * Ekin - self.omega * float(Peta0.squeeze())
+            )
         else:
             raise ValueError(
                 "Either Eprime and mu must be provided, or Ekin, lam, and p0 "

--- a/src/firm3d/field/trajectory_helpers.py
+++ b/src/firm3d/field/trajectory_helpers.py
@@ -1379,9 +1379,13 @@ class PassingPerturbedPoincare:
                 helicity_M,
                 helicity_N,
             )
-            self.Eprime = float(
-                self.nprime * Ekin - self.omega * float(Peta0.squeeze())
-            )
+            Peta0_arr = np.asarray(Peta0)
+            if Peta0_arr.size != 1:
+                raise ValueError(
+                    f"Peta0 must be scalar-like (size 1), got shape "
+                    f"{Peta0_arr.shape} and size {Peta0_arr.size}"
+                )
+            self.Eprime = float(self.nprime * Ekin - self.omega * Peta0_arr.item())
         else:
             raise ValueError(
                 "Either Eprime and mu must be provided, or Ekin, lam, and p0 "

--- a/src/firm3d/field/trajectory_helpers.py
+++ b/src/firm3d/field/trajectory_helpers.py
@@ -1379,7 +1379,7 @@ class PassingPerturbedPoincare:
                 helicity_M,
                 helicity_N,
             )
-            self.Eprime = self.nprime * Ekin - self.omega * Peta0
+            self.Eprime = float(self.nprime * Ekin - self.omega * float(Peta0.squeeze()))
         else:
             raise ValueError(
                 "Either Eprime and mu must be provided, or Ekin, lam, and p0 "
@@ -1603,6 +1603,7 @@ class PassingPerturbedPoincare:
             tmax=self.tmax,
             mass=self.mass,
             charge=self.charge,
+            Ekin=self.Ekin,
             phases=phases,
             n_zetas=n_zetas,
             m_thetas=m_thetas,
@@ -1613,7 +1614,7 @@ class PassingPerturbedPoincare:
                 MinToroidalFluxStoppingCriterion(0.01),
                 MaxToroidalFluxStoppingCriterion(1.0),
             ],
-            forget_exact_path=True,
+            forget_exact_path=not self.DA_poinc,
             vpars_stop=True,
             phases_stop=True,
             **self.solver_options,

--- a/src/firm3d/util/functions.py
+++ b/src/firm3d/util/functions.py
@@ -1,8 +1,11 @@
 import builtins
 import logging
+import os
 import sys
 
 from .mpi import verbose
+
+in_github_actions = os.getenv("GITHUB_ACTIONS") == "true"
 
 
 def print(*args, **kwargs):


### PR DESCRIPTION
- Fix NumPy 2.x compatibility in tracing.py: use float(np.sqrt(...)) and cast all args to sopp pybind11 bindings to Python types
- Fix PassingPerturbedPoincare in trajectory_helpers.py:
  - Eprime computed as scalar (Peta0 from compute_peta is shape (1,))
  - Add missing Ekin= arg to trace_particles_boozer_perturbed call
  - Fix forget_exact_path=True -> not self.DA_poinc (WBA needs full path)
- Add in_github_actions flag to firm3d.util.functions
- Scale down all 16 example scripts for CI via in_github_actions
- Add 'examples' job to CI workflow running all 16 scripts

## Summary by Sourcery

Add CI coverage for running all example scripts in a reduced-cost configuration and fix issues in perturbed passing map tracing and NumPy compatibility.

Bug Fixes:
- Fix NumPy 2.x compatibility in perturbed particle tracing by ensuring scalar float and Python-type arguments are passed to pybind11 bindings.
- Correct PassingPerturbedPoincare energy and trajectory handling by computing Eprime as a scalar, passing Ekin to tracing, and preserving full paths when required.

Enhancements:
- Introduce an in_github_actions flag to conditionally scale down example problem sizes and solver tolerances for faster CI execution.

CI:
- Add an examples job to the GitHub Actions workflow that installs dependencies and runs all example scripts under Python 3.11.