### PR TITLE
Add nlohmann_json dependency to install scripts

### DIFF
--- a/install/macOS/install_firm3d_osx.sh
+++ b/install/macOS/install_firm3d_osx.sh
@@ -29,7 +29,7 @@ check_success "Failed to activate conda environment $env_name"
 
 # Install Dependencies
 echo "Installing FIRM3D dependencies..."
-conda install -y compilers netcdf-fortran openmpi-mpicc openmpi-mpifort openblas scalapack gsl matplotlib --name "$env_name"
+conda install -y compilers netcdf-fortran openmpi-mpicc openmpi-mpifort openblas scalapack gsl matplotlib nlohmann_json --name "$env_name"
 pip install mpi4py
 check_success "Failed to install FIRM3D dependencies"
 

--- a/install/perlmutter/install_firm3d_perlmutter.sh
+++ b/install/perlmutter/install_firm3d_perlmutter.sh
@@ -33,6 +33,9 @@ echo "Activating conda environment: $env_name"
 source activate "$env_name" || conda activate "$env_name"
 check_success "Failed to activate conda environment $env_name"
 
+# Install json loading dependency
+pip install nlohmann-json
+
 # FIRM3D Installation
 cd firm3d || { echo "Error: firm3d directory not found. Exiting."; exit 1; }
 export CI=True


### PR DESCRIPTION
The install script for macOS and perlmutter did not install the `nlohmann_json` dependency after #26 , causing a crash when trying to build. 

This PR ensures that the install scripts add the package before trying to build firm3d.

## Summary by Sourcery

Ensure FIRM3D install scripts install the required nlohmann_json JSON dependency before building on macOS and Perlmutter.

Bug Fixes:
- Add installation of the nlohmann_json dependency to the Perlmutter install script to prevent build-time crashes.
- Include nlohmann_json in the macOS conda dependency list so local builds succeed.