### PR TITLE
Fixing out-of-bounds issues with cpp interpolant.

### DIFF
--- a/.github/workflows/perlmutter-ci.yml
+++ b/.github/workflows/perlmutter-ci.yml
@@ -18,7 +18,7 @@ jobs:
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'GPU CI')
     runs-on: [perlmutter]
-    timeout-minutes: 60
+    timeout-minutes: 360
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM"]
+select = ["E", "W", "F", "N", "UP", "B", "C4", "SIM"]
 ignore = ["E731", "E741", "E722", "N816", "N803", "N806", "N802"]

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -202,13 +202,17 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double y, doubl
         if(zidx < 0 || zidx >= nz)
             throw std::runtime_error((boost::format("zidxs={} not within [0, {}]") % zidx % (nz-1)).str());
     } else {
-        // Clamp cell index to valid range (matching CUDA kernel behaviour):
-        // the coordinate is left at its true value so xlocal can exceed [0,1),
-        // giving polynomial extrapolation from the last cell rather than
-        // returning zero (which previously caused modB=0 and an unbounded RHS).
+        // Clamp cell indices to match CUDA kernel convention (cuda_kernel.cu:700-704):
+        //   x (s, radial): clamp both lower and upper bounds — s can legitimately
+        //     fall below 0 or above 1 during tracing.
+        //   y (theta), z (zeta): clamp upper bound only — these are periodic
+        //     coordinates and a negative index never occurs in practice.
+        // The coordinate itself is left at its true value so that xlocal can
+        // exceed [0,1), giving polynomial extrapolation from the boundary cell
+        // rather than returning zero (which caused modB=0 and an unbounded RHS).
         xidx = std::max(0, std::min(nx-1, xidx));
-        yidx = std::max(0, std::min(ny-1, yidx));
-        zidx = std::max(0, std::min(nz-1, zidx));
+        yidx = std::min(ny-1, yidx);
+        zidx = std::min(nz-1, zidx);
     }
     double xlocal = (x-xmesh[xidx])/hx;
     double ylocal = (y-ymesh[yidx])/hy;

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -21,7 +21,7 @@ template<class Array>
 void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, Vec, Vec)> &f) {
     int BATCH_SIZE = 16384;
     int NUM_BATCHES = dofs_to_keep/BATCH_SIZE + (dofs_to_keep % BATCH_SIZE != 0);
-    
+
     for (int i = 0; i < NUM_BATCHES; ++i) {
         uint32_t first = i * BATCH_SIZE;
         uint32_t last = std::min((uint32_t)((i+1) * BATCH_SIZE), dofs_to_keep);
@@ -78,7 +78,7 @@ void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, V
 
     int BATCH_SIZE = 16384;
     Vec local_vals(local_dofs * value_size, 0.);
-    
+
     for (int first = local_first; first < local_last; first += BATCH_SIZE) {
         int last = std::min(first + BATCH_SIZE, local_last);
         Vec xsub(xdoftensor_reduced.begin() + first, xdoftensor_reduced.begin() + last);
@@ -201,6 +201,14 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double y, doubl
             throw std::runtime_error((boost::format("yidxs={} not within [0, {}]") % yidx % (ny-1)).str());
         if(zidx < 0 || zidx >= nz)
             throw std::runtime_error((boost::format("zidxs={} not within [0, {}]") % zidx % (nz-1)).str());
+    } else {
+        // Clamp cell index to valid range (matching CUDA kernel behaviour):
+        // the coordinate is left at its true value so xlocal can exceed [0,1),
+        // giving polynomial extrapolation from the last cell rather than
+        // returning zero (which previously caused modB=0 and an unbounded RHS).
+        xidx = std::max(0, std::min(nx-1, xidx));
+        yidx = std::max(0, std::min(ny-1, yidx));
+        zidx = std::max(0, std::min(nz-1, zidx));
     }
     double xlocal = (x-xmesh[xidx])/hx;
     double ylocal = (y-ymesh[yidx])/hy;
@@ -210,7 +218,7 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double y, doubl
 
 template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double* res){
-    
+
     // to avoid funny business when the data is just a tiny bit out of bounds
     // due to machine precision, we perform this check and shift
     if(x >= xmax) x -= _EPS_;
@@ -221,6 +229,10 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double* res){
     if(!out_of_bounds_ok){
         if(xidx < 0 || xidx >= nx)
             throw std::runtime_error((boost::format("xidxs={} not within [0, {}]") % xidx % (nx-1)).str());
+    } else {
+        // Clamp cell index (matching CUDA kernel behaviour): extrapolate from
+        // last cell rather than returning zero.
+        xidx = std::max(0, std::min(nx-1, xidx));
     }
     double xlocal = (x-xmesh[xidx])/hx;
     return evaluate_local(xlocal, idx_cell(xidx, 0, 0), res);
@@ -401,7 +413,7 @@ void RegularGridInterpolant3D<Array>::set_interpolant_data(const std::map<std::s
     if (it != data.end()) {
         vals = it->second;
     }
-    
+
     // Rebuild all_local_vals_map from vals. This is the cell-indexed lookup table
     // used by evaluate_local() - same construction as interpolate_batch() but
     // without calling the function to compute values.

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -92,7 +92,7 @@ def construct_interpolant(field, nfp, saw_present=False):
 def sample_test_points(n_test_pts):
     np.random.seed(1865)
     # generate test points
-    s = np.random.uniform(low=0, high=0.95, size=(n_test_pts, 1))
+    s = np.random.uniform(low=0, high=1.1, size=(n_test_pts, 1))
     t = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
     z = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
     stz = np.hstack((s, t, z))
@@ -874,79 +874,6 @@ class TestGPUTracing(unittest.TestCase):
             tol=tol,
         )
         self.assertTrue(is_small)
-
-    def test_out_of_bounds_cpu_gpu_parity(self):
-        """Verify CPU and GPU interpolants agree (and are non-zero) for s > 1.
-
-        When a particle escapes the last flux surface (s > 1) the interpolant
-        should extrapolate using the boundary cell rather than silently return
-        zero.  This test checks that both CPU (RegularGridInterpolant3D) and
-        GPU (CUDA kernel) exhibit that clamped-cell extrapolation behaviour and
-        that their outputs match each other.
-        """
-        n_metagrid_pts = 15
-        boozmn_filename = "examples/inputs/boozmn_aten_rescaled_low_res.nc"
-        bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum=True)
-
-        # Build the interpolant (needed for the GPU call).
-        srange, trange, zrange, quad_info, _maxJ = construct_interpolant(field, nfp)
-
-        # Sample points strictly outside the plasma (s > 1).
-        n_test_pts = 100
-        np.random.seed(42)
-        s_oob = np.random.uniform(low=1.01, high=1.10, size=(n_test_pts, 1))
-        t_oob = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
-        z_oob = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
-        stz_oob = np.hstack((s_oob, t_oob, z_oob))
-
-        # --- CPU evaluation ---
-        field.set_points(stz_oob)
-        modB_cpu = field.modB()
-        modB_derivs_cpu = field.modB_derivs()
-        G_cpu = field.G()
-        iota_cpu = field.iota()
-        cpu_vals = np.hstack((modB_cpu, modB_derivs_cpu, G_cpu, iota_cpu))
-
-        # --- GPU evaluation ---
-        stz_contig = np.ascontiguousarray(stz_oob)
-        gpu_raw = firm3dpp.test_gpu_interpolation(
-            quad_info,
-            srange,
-            trange,
-            zrange,
-            stz_contig.copy(),
-            "boozer_vacuum",
-            n_test_pts,
-        )
-        gpu_vals = np.reshape(gpu_raw, (n_test_pts, -1))
-
-        # Both CPU and GPU must return non-zero modB (the most critical quantity).
-        # A zero modB would cause infinite RHS in the guiding-centre equations.
-        self.assertTrue(
-            np.all(modB_cpu != 0),
-            "CPU interpolant returned zero modB for out-of-bounds (s>1) points; "
-            "expected non-zero extrapolated values.",
-        )
-        self.assertTrue(
-            np.all(gpu_vals[:, 0:1] != 0),
-            "GPU interpolant returned zero modB for out-of-bounds (s>1) points; "
-            "expected non-zero extrapolated values.",
-        )
-
-        # CPU and GPU outputs must agree (same clamped-cell extrapolation).
-        tol = 1e-8
-        close = np.isclose(gpu_vals, cpu_vals, rtol=tol, atol=tol).all()
-        if not close:
-            error = np.abs(cpu_vals - gpu_vals) / (np.abs(cpu_vals) + 1)
-            row_idx = np.unravel_index(np.argmax(error), error.shape)[0]
-            print("OOB parity failure at stz:", stz_oob[row_idx, :])
-            print("  cpu:", cpu_vals[row_idx, :])
-            print("  gpu:", gpu_vals[row_idx, :])
-            print("  rel error:", error[row_idx, :])
-        self.assertTrue(
-            close,
-            "CPU and GPU interpolants disagree for out-of-bounds (s>1) points.",
-        )
 
     @unittest.skipUnless(HAS_SIMSOPT, "simsopt not available")
     def test_cartesian_vacuum(self):

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -6,6 +6,11 @@ import numpy as np
 import firm3dpp
 
 try:
+    from simsopt.field.tracing import (
+        IterationStoppingCriterion as SimsoptIterationStoppingCriterion,
+    )
+    from simsopt.geo import SurfaceRZFourier
+
     from simsopt.field import (
         BiotSavart,
         InterpolatedField,
@@ -14,10 +19,6 @@ try:
         load_coils_from_makegrid_file,
         trace_particles,
     )
-    from simsopt.field.tracing import (
-        IterationStoppingCriterion as SimsoptIterationStoppingCriterion,
-    )
-    from simsopt.geo import SurfaceRZFourier
 
     HAS_SIMSOPT = True
 except Exception:
@@ -873,6 +874,79 @@ class TestGPUTracing(unittest.TestCase):
             tol=tol,
         )
         self.assertTrue(is_small)
+
+    def test_out_of_bounds_cpu_gpu_parity(self):
+        """Verify CPU and GPU interpolants agree (and are non-zero) for s > 1.
+
+        When a particle escapes the last flux surface (s > 1) the interpolant
+        should extrapolate using the boundary cell rather than silently return
+        zero.  This test checks that both CPU (RegularGridInterpolant3D) and
+        GPU (CUDA kernel) exhibit that clamped-cell extrapolation behaviour and
+        that their outputs match each other.
+        """
+        n_metagrid_pts = 15
+        boozmn_filename = "examples/inputs/boozmn_aten_rescaled_low_res.nc"
+        bri, field, nfp = get_field(boozmn_filename, n_metagrid_pts, vacuum=True)
+
+        # Build the interpolant (needed for the GPU call).
+        srange, trange, zrange, quad_info, _maxJ = construct_interpolant(field, nfp)
+
+        # Sample points strictly outside the plasma (s > 1).
+        n_test_pts = 100
+        np.random.seed(42)
+        s_oob = np.random.uniform(low=1.01, high=1.10, size=(n_test_pts, 1))
+        t_oob = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
+        z_oob = np.random.uniform(low=0, high=2 * np.pi, size=(n_test_pts, 1))
+        stz_oob = np.hstack((s_oob, t_oob, z_oob))
+
+        # --- CPU evaluation ---
+        field.set_points(stz_oob)
+        modB_cpu = field.modB()
+        modB_derivs_cpu = field.modB_derivs()
+        G_cpu = field.G()
+        iota_cpu = field.iota()
+        cpu_vals = np.hstack((modB_cpu, modB_derivs_cpu, G_cpu, iota_cpu))
+
+        # --- GPU evaluation ---
+        stz_contig = np.ascontiguousarray(stz_oob)
+        gpu_raw = firm3dpp.test_gpu_interpolation(
+            quad_info,
+            srange,
+            trange,
+            zrange,
+            stz_contig.copy(),
+            "boozer_vacuum",
+            n_test_pts,
+        )
+        gpu_vals = np.reshape(gpu_raw, (n_test_pts, -1))
+
+        # Both CPU and GPU must return non-zero modB (the most critical quantity).
+        # A zero modB would cause infinite RHS in the guiding-centre equations.
+        self.assertTrue(
+            np.all(modB_cpu != 0),
+            "CPU interpolant returned zero modB for out-of-bounds (s>1) points; "
+            "expected non-zero extrapolated values.",
+        )
+        self.assertTrue(
+            np.all(gpu_vals[:, 0:1] != 0),
+            "GPU interpolant returned zero modB for out-of-bounds (s>1) points; "
+            "expected non-zero extrapolated values.",
+        )
+
+        # CPU and GPU outputs must agree (same clamped-cell extrapolation).
+        tol = 1e-8
+        close = np.isclose(gpu_vals, cpu_vals, rtol=tol, atol=tol).all()
+        if not close:
+            error = np.abs(cpu_vals - gpu_vals) / (np.abs(cpu_vals) + 1)
+            row_idx = np.unravel_index(np.argmax(error), error.shape)[0]
+            print("OOB parity failure at stz:", stz_oob[row_idx, :])
+            print("  cpu:", cpu_vals[row_idx, :])
+            print("  gpu:", gpu_vals[row_idx, :])
+            print("  rel error:", error[row_idx, :])
+        self.assertTrue(
+            close,
+            "CPU and GPU interpolants disagree for out-of-bounds (s>1) points.",
+        )
 
     @unittest.skipUnless(HAS_SIMSOPT, "simsopt not available")
     def test_cartesian_vacuum(self):


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent out-of-bounds access in the C++ regular grid interpolant by clamping indices instead of returning zero when extrapolating beyond the grid.